### PR TITLE
Fix/recursive types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xometry/graphql-code-generator-subset-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A plugin for graphql-code-generator that will take a full schema and a set of operations, and produce a subset schema.",
   "main": "dist/src/plugin.js",
   "repository": "https://github.com/xometry/graphql-code-generator-subset-plugin",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,6 +12,7 @@ import {
   isInterfaceType,
   isUnionType,
   GraphQLInputObjectType,
+  buildSchema,
 } from "graphql";
 import { Types, PluginFunction } from "@graphql-codegen/plugin-helpers";
 
@@ -25,9 +26,10 @@ export const plugin: PluginFunction = (
     );
   }
 
-  const typeInfo = new TypeInfo(schema);
+  const typeInfo = new TypeInfo(buildSchema(printSchema(schema)));
   const usedObjectFields = new Map<string, Set<string>>(); // objects and interfaces
   const otherUsedTypes = new Set<string>();
+  const alreadyProcessedTypes = new Set<string>();
 
   function visitType(type: GraphQLType | undefined | null) {
     if (!type) {
@@ -62,8 +64,12 @@ export const plugin: PluginFunction = (
     otherUsedTypes.add(resolvedType.name);
 
     const kind = resolvedType.astNode?.kind;
-    if (kind === "InputObjectTypeDefinition") {
+    if (
+      kind === "InputObjectTypeDefinition" &&
+      !alreadyProcessedTypes.has(resolvedType.name)
+    ) {
       const inputType = resolvedType as GraphQLInputObjectType;
+      alreadyProcessedTypes.add(inputType.name);
       Object.values(inputType.getFields()).forEach((field) => {
         recursivelyVisitInputType(field.type);
       });


### PR DESCRIPTION
I encountered two issues when attempting to use this plugin:
1. The `kind` variable is always `undefined`, so no `otherUsedTypes` are ever processed.  This is due to the `resolvedType.astNode` always being `undefined`.
2. The code would enter an infinite loop if the graphql schema contains circular references.

These issues are resolved by:
1. Implementing a workaround from (this issue)[https://github.com/graphql/graphql-js/issues/1575] to get all `astNode` fields in the schema to be properly instantiated when loading the schema. 
2. Instantiate a Set of input types already processed, add input types when they are first processed, and prevent infinite loop by skipping these if encountered more than once. 

